### PR TITLE
Motion selector implementation for motion primtives

### DIFF
--- a/geometric_controller/launch/trajectory_controller.launch
+++ b/geometric_controller/launch/trajectory_controller.launch
@@ -6,7 +6,7 @@
   <arg name="tgt_component" default="1" />
   <arg name="command_input" default="2" />
   <arg name="gazebo_simulation" default="true" />
-  <arg name="visualization" default="false"/>
+  <arg name="visualization" default="true"/>
 
 
   <node pkg="geometric_controller" type="geometric_controller" name="geometric_controller" output="screen">
@@ -15,6 +15,10 @@
           <param name="ctrl_mode" value="$(arg command_input)" />
           <param name="enable_sim" value="$(arg gazebo_simulation)" />
   </node>
+
+  <node pkg="trajectory_publisher" type="trajectory_publisher" name="trajectory_publisher" output="screen">
+  </node>
+
 
   <node name="mavros" pkg="mavros" type="mavros_node" output="screen">
       <param name="fcu_url" value="$(arg fcu_url)" />

--- a/trajectory_publisher/include/trajectory_publisher/trajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectory.h
@@ -17,6 +17,8 @@ class trajectory {
 
   public:
     trajectory(double duration);
+    void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel);
+    void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc);
     void setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorXd &y_coefficients, Eigen::VectorXd &z_coefficients);
     Eigen::VectorXd getCoefficients(int dim);
     Eigen::Vector3d getPosition(double time);

--- a/trajectory_publisher/include/trajectory_publisher/trajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectory.h
@@ -19,6 +19,8 @@ class trajectory {
     trajectory(double duration);
     void setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorXd &y_coefficients, Eigen::VectorXd &z_coefficients);
     Eigen::VectorXd getCoefficients(int dim);
+    Eigen::Vector3d getPosition(double time);
+    Eigen::Vector3d getVelocity(double time);
 };
 
 

--- a/trajectory_publisher/include/trajectory_publisher/trajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectory.h
@@ -6,6 +6,8 @@
 #define TRAJECTORY_PUBLISHER_TRAJECTORY_H
 
 #include <Eigen/Dense>
+#include <nav_msgs/Path.h>
+#include <geometry_msgs/PoseStamped.h>
 
 
 class trajectory {
@@ -25,6 +27,9 @@ class trajectory {
     Eigen::Vector3d getVelocity(double time);
     double getsamplingTime(){return dt_;};
     double getDuration(){ return T_;};
+    nav_msgs::Path getSegment();
+    geometry_msgs::PoseStamped vector3d2PoseStampedMsg(Eigen::Vector3d position, Eigen::Vector4d orientation);
+
 };
 
 

--- a/trajectory_publisher/include/trajectory_publisher/trajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectory.h
@@ -15,10 +15,11 @@ class trajectory {
     int N; //Degree of polynomial
     double dt_; //Sampling time
     double T_;
-    Eigen::VectorXd c_x_, c_y_, c_z_; //Coefficients for polynomial representation
+    Eigen::Vector3d c_x_, c_y_, c_z_; //Coefficients for polynomial representation
 
   public:
-    trajectory(double duration);
+    trajectory();
+    ~trajectory();
     void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel);
     void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc);
     void setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorXd &y_coefficients, Eigen::VectorXd &z_coefficients);

--- a/trajectory_publisher/include/trajectory_publisher/trajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectory.h
@@ -23,6 +23,8 @@ class trajectory {
     Eigen::VectorXd getCoefficients(int dim);
     Eigen::Vector3d getPosition(double time);
     Eigen::Vector3d getVelocity(double time);
+    double getsamplingTime(){return dt_;};
+    double getDuration(){ return T_;};
 };
 
 

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -18,6 +18,7 @@
 
 #include <ros/ros.h>
 #include <std_msgs/String.h>
+#include <std_msgs/Int32.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <std_srvs/SetBool.h>
@@ -35,6 +36,7 @@ private:
   ros::NodeHandle nh_private_;
   ros::Publisher trajectoryPub_;
   ros::Publisher referencePub_;
+  ros::Subscriber motionselectorSub_;
   ros::ServiceServer trajtriggerServ_;
   ros::Timer trajloop_timer_;
   ros::Timer refloop_timer_;
@@ -54,6 +56,7 @@ private:
   double trigger_time_;
   double init_pos_x_, init_pos_y_, init_pos_z_;
   int target_trajectoryID_;
+  int motion_selector_;
 
   trajectory motionPrimitives_;
 

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -37,6 +37,8 @@ private:
   ros::Publisher trajectoryPub_;
   ros::Publisher referencePub_;
   ros::Subscriber motionselectorSub_;
+  ros::Subscriber mavposeSub_;
+  ros::Subscriber mavtwistSub_;
   ros::ServiceServer trajtriggerServ_;
   ros::Timer trajloop_timer_;
   ros::Timer refloop_timer_;
@@ -50,9 +52,11 @@ private:
   Eigen::Vector3d target_initpos;
   Eigen::Vector3d traj_axis_;
   Eigen::Vector3d p_targ, v_targ;
+  Eigen::Vector3d p_mav_, v_mav_;
   double traj_radius_, traj_omega_;
   double theta_ = 0.0;
   double controlUpdate_dt_;
+  double primitive_duration_;
   double trigger_time_;
   double init_pos_x_, init_pos_y_, init_pos_z_;
   int target_trajectoryID_;
@@ -60,6 +64,7 @@ private:
   int motion_selector_;
 
   std::vector<trajectory> motionPrimitives_;
+  std::vector<Eigen::Vector3d> inputs_;
 
 
 public:
@@ -73,13 +78,16 @@ public:
   void pubrefTrajectory();
   void pubrefState();
   geometry_msgs::PoseStamped vector3d2PoseStampedMsg(Eigen::Vector3d position, Eigen::Vector4d orientation);
+  void initializePrimitives();
+  void updatePrimitives();
   Eigen::Vector3d getTargetPosition();
   void loopCallback(const ros::TimerEvent& event);
   void refCallback(const ros::TimerEvent& event);
   bool triggerCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
   void trajectoryCallback(const mav_planning_msgs::PolynomialTrajectory4D& segments_message);
   void motionselectorCallback(const std_msgs::Int32& selector);
-
+  void mavposeCallback(const geometry_msgs::PoseStamped& msg);
+  void mavtwistCallback(const geometry_msgs::TwistStamped& msg);
 
   };
 

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -56,9 +56,10 @@ private:
   double trigger_time_;
   double init_pos_x_, init_pos_y_, init_pos_z_;
   int target_trajectoryID_;
+  int num_primitives_;
   int motion_selector_;
 
-  trajectory motionPrimitives_;
+  std::vector<trajectory> motionPrimitives_;
 
 
 public:
@@ -77,6 +78,8 @@ public:
   void refCallback(const ros::TimerEvent& event);
   bool triggerCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
   void trajectoryCallback(const mav_planning_msgs::PolynomialTrajectory4D& segments_message);
+  void motionselectorCallback(const std_msgs::Int32& selector);
+
 
   };
 

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -36,6 +36,7 @@ private:
   ros::NodeHandle nh_private_;
   ros::Publisher trajectoryPub_;
   ros::Publisher referencePub_;
+  ros::Publisher primitivePub_;
   ros::Subscriber motionselectorSub_;
   ros::Subscriber mavposeSub_;
   ros::Subscriber mavtwistSub_;
@@ -44,7 +45,7 @@ private:
   ros::Timer refloop_timer_;
   ros::Time start_time_, curr_time_;
 
-  nav_msgs::Path refTrajectory_;
+  nav_msgs::Path refTrajectory_, primTrajectory_;
   geometry_msgs::TwistStamped refState_;
 
   int counter;
@@ -75,7 +76,8 @@ public:
   double getTrajectoryOmega();
   double getTrajectoryUpdateRate();
   void moveReference();
-  void pubrefTrajectory();
+  void pubrefTrajectory(int selector);
+  void pubprimitiveTrajectory();
   void pubrefState();
   geometry_msgs::PoseStamped vector3d2PoseStampedMsg(Eigen::Vector3d position, Eigen::Vector4d orientation);
   void initializePrimitives();

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -79,7 +79,6 @@ public:
   void pubrefTrajectory(int selector);
   void pubprimitiveTrajectory();
   void pubrefState();
-  geometry_msgs::PoseStamped vector3d2PoseStampedMsg(Eigen::Vector3d position, Eigen::Vector4d orientation);
   void initializePrimitives();
   void updatePrimitives();
   Eigen::Vector3d getTargetPosition();

--- a/trajectory_publisher/launch/config_file.rviz
+++ b/trajectory_publisher/launch/config_file.rviz
@@ -1,0 +1,147 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Grid1
+        - /Grid1/Status1
+        - /Pose1
+        - /Pose2
+      Splitter Ratio: 0.5
+    Tree Height: 775
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.100000001
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.300000012
+      Head Radius: 0.100000001
+      Name: Pose
+      Shaft Length: 1
+      Shaft Radius: 0.0500000007
+      Shape: Axes
+      Topic: /mavros/local_position/pose
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.100000001
+      Class: rviz/Pose
+      Color: 0; 255; 0
+      Enabled: true
+      Head Length: 0.300000012
+      Head Radius: 0.100000001
+      Name: Pose
+      Shaft Length: 1
+      Shaft Radius: 0.0500000007
+      Shape: Axes
+      Topic: /iris/reference/pose
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 10
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.0500000007
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Pitch: 0.465398014
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.735397995
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1056
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000396fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000396000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000396fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000002800000396000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d00650100000000000007800000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000004fb0000039600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1920
+  X: 0
+  Y: 24

--- a/trajectory_publisher/launch/trajectory_publisher.launch
+++ b/trajectory_publisher/launch/trajectory_publisher.launch
@@ -1,0 +1,7 @@
+<launch>
+
+  <node pkg="trajectory_publisher" type="trajectory_publisher" name="trajectory_publisher" output="screen">
+  </node>
+
+
+</launch>

--- a/trajectory_publisher/src/trajectory.cpp
+++ b/trajectory_publisher/src/trajectory.cpp
@@ -23,6 +23,34 @@ void trajectory::setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorX
 
 }
 
+void trajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel){
+  //Generate primitives based on current state for smooth trajectory
+  c_x_(0) = pos(0);
+  c_y_(0) = pos(1);
+  c_z_(0) = pos(2);
+
+  c_x_(1) = vel(0);
+  c_y_(1) = vel(1);
+  c_z_(1) = vel(2);
+
+}
+
+void trajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc){
+  //Generate primitives based on current state for smooth trajectory
+  c_x_(0) = pos(0);
+  c_y_(0) = pos(1);
+  c_z_(0) = pos(2);
+
+  c_x_(1) = vel(0);
+  c_y_(1) = vel(1);
+  c_z_(1) = vel(2);
+
+  c_x_(2) = acc(0);
+  c_y_(2) = acc(1);
+  c_z_(2) = acc(2);
+
+}
+
 Eigen::VectorXd trajectory::getCoefficients(int dim){
 
   switch(dim) {

--- a/trajectory_publisher/src/trajectory.cpp
+++ b/trajectory_publisher/src/trajectory.cpp
@@ -4,16 +4,20 @@
 
 #include "trajectory_publisher/trajectory.h"
 
-trajectory::trajectory(double duration) :
+trajectory::trajectory() :
   N(0),
   dt_(0.1),
-  T_(duration) {
+  T_(0.1) {
 
   c_x_ << 0.0, 0.0, 0.0;
   c_y_ << 0.0, 0.0, 0.0;
   c_z_ << 0.0, 0.0, 0.0;
 
 }
+
+trajectory::~trajectory(){
+
+};
 
 void trajectory::setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorXd &y_coefficients, Eigen::VectorXd &z_coefficients){
 
@@ -99,6 +103,7 @@ nav_msgs::Path trajectory::getSegment(){
     targetPoseStamped = vector3d2PoseStampedMsg(targetPosition, targetOrientation);
     segment.poses.push_back(targetPoseStamped);
   }
+  return segment;
 }
 
 geometry_msgs::PoseStamped trajectory::vector3d2PoseStampedMsg(Eigen::Vector3d position, Eigen::Vector4d orientation){

--- a/trajectory_publisher/src/trajectory.cpp
+++ b/trajectory_publisher/src/trajectory.cpp
@@ -9,6 +9,10 @@ trajectory::trajectory(double duration) :
   dt_(0.1),
   T_(duration) {
 
+  c_x_ << 0.0, 0.0, 0.0;
+  c_y_ << 0.0, 0.0, 0.0;
+  c_z_ << 0.0, 0.0, 0.0;
+
 }
 
 void trajectory::setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorXd &y_coefficients, Eigen::VectorXd &z_coefficients){
@@ -21,9 +25,32 @@ void trajectory::setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorX
 
 Eigen::VectorXd trajectory::getCoefficients(int dim){
 
-  switch(dim){
-    case 0 : return c_x_;
-    case 1 : return c_y_;
-    case 2 : return c_z_;
+  switch(dim) {
+    case 0 :
+      return c_x_;
+    case 1 :
+      return c_y_;
+    case 2 :
+      return c_z_;
   }
+}
+
+Eigen::Vector3d trajectory::getPosition(double time){
+
+  Eigen::Vector3d position;
+  position << c_x_(0) + c_x_(1) * time + c_x_(2) * pow(time, 2) + c_x_(3) * pow(time, 3),
+             c_y_(0) + c_y_(1) * time + c_y_(2) * pow(time, 2) + c_y_(3) * pow(time, 3),
+             c_z_(0) + c_z_(1) * time + c_z_(2) * pow(time, 2) + c_z_(3) * pow(time, 3);
+  return position;
+
+}
+
+Eigen::Vector3d trajectory::getVelocity(double time){
+
+  Eigen::Vector3d velocity;
+  velocity << c_x_(1) + c_x_(2) * time * 2 + c_x_(3) * pow(time, 2) * 3,
+              c_y_(1) + c_y_(2) * time * 2 + c_y_(3) * pow(time, 2) * 3,
+              c_z_(1) + c_z_(2) * time * 2 + c_z_(3) * pow(time, 2) * 3;
+  return velocity;
+
 }

--- a/trajectory_publisher/src/trajectory.cpp
+++ b/trajectory_publisher/src/trajectory.cpp
@@ -82,3 +82,35 @@ Eigen::Vector3d trajectory::getVelocity(double time){
   return velocity;
 
 }
+
+nav_msgs::Path trajectory::getSegment(){
+
+  Eigen::Vector3d targetPosition;
+  Eigen::Vector4d targetOrientation;
+  nav_msgs::Path segment;
+
+  int N = T_/dt_; //Resolution of the trajectory to be published
+
+  targetOrientation << 1.0, 0.0, 0.0, 0.0;
+  geometry_msgs::PoseStamped targetPoseStamped;
+
+  for(int i = 0 ; i < N ; i++){
+    targetPosition = this->getPosition(i*dt_);
+    targetPoseStamped = vector3d2PoseStampedMsg(targetPosition, targetOrientation);
+    segment.poses.push_back(targetPoseStamped);
+  }
+}
+
+geometry_msgs::PoseStamped trajectory::vector3d2PoseStampedMsg(Eigen::Vector3d position, Eigen::Vector4d orientation){
+  geometry_msgs::PoseStamped encode_msg;
+  encode_msg.header.stamp = ros::Time::now();
+  encode_msg.header.frame_id = "map";
+  encode_msg.pose.orientation.w = orientation(0);
+  encode_msg.pose.orientation.x = orientation(1);
+  encode_msg.pose.orientation.y = orientation(2);
+  encode_msg.pose.orientation.z = orientation(3);
+  encode_msg.pose.position.x = position(0);
+  encode_msg.pose.position.y = position(1);
+  encode_msg.pose.position.z = position(2);
+  return encode_msg;
+}

--- a/trajectory_publisher/src/trajectoryPublisher.cpp
+++ b/trajectory_publisher/src/trajectoryPublisher.cpp
@@ -19,8 +19,8 @@ trajectoryPublisher::trajectoryPublisher(const ros::NodeHandle& nh, const ros::N
   trajtriggerServ_ = nh_.advertiseService("start", &trajectoryPublisher::triggerCallback, this);
 
   nh_.param<double>("/trajectory_publisher/initpos_x", init_pos_x_, 0.0);
-  nh_.param<double>("/trajectory_publisher/initpos_x", init_pos_y_, 0.0);
-  nh_.param<double>("/trajectory_publisher/initpos_x", init_pos_z_, 1.0);
+  nh_.param<double>("/trajectory_publisher/initpos_y", init_pos_y_, 0.0);
+  nh_.param<double>("/trajectory_publisher/initpos_z", init_pos_z_, 1.0);
   nh_.param<double>("/trajectory_publisher/updaterate", controlUpdate_dt_, 0.01);
   nh_.param<int>("/trajectory_publisher/trajectoryID", target_trajectoryID_, 0);
 
@@ -75,13 +75,10 @@ void trajectoryPublisher::moveReference() {
   trigger_time_ = (curr_time_ - start_time_).toSec();
 
   if(mode_ == MODE_PRIMITIVES){
-    //TODO: Play reference trajectory based on time
-//    p_targ << a0x + a1x*trigger_time_ + a2x*trigger_time_^2 + a3x*trigger)time_^3,
-//              a0y + a1y*trigger_time_ + a2y*trigger_time_^2 + a3y*trigger)time_^3,
-//              a0z + a1z*trigger_time_ + a2z*trigger_time_^2 + a3z*trigger)time_^3;
-//    v_targ << a1 + 2*a2*trigger_time_ + 3*a3*trigger)time_^2,
-//              a1 + 2*a2*trigger_time_ + 3*a3*trigger)time_^2,
-//              a1 + 2*a2*trigger_time_ + 3*a3*trigger)time_^2;
+
+    p_targ = motionPrimitives_.getPosition(trigger_time_);
+    v_targ = motionPrimitives_.getVelocity(trigger_time_);
+
   }
   else if(mode_ == MODE_REFERENCE){
     theta_ = traj_omega_* trigger_time_;

--- a/trajectory_publisher/src/trajectoryPublisher.cpp
+++ b/trajectory_publisher/src/trajectoryPublisher.cpp
@@ -158,24 +158,22 @@ geometry_msgs::PoseStamped trajectoryPublisher::vector3d2PoseStampedMsg(Eigen::V
 
 void trajectoryPublisher::pubrefTrajectory(){
 
-int N = (int) 2*3.141592 / this->getTrajectoryOmega() / this->getTrajectoryUpdateRate(); //Resolution of the trajectory to be published
-double theta;
-Eigen::Vector3d targetPosition;
-Eigen::Vector4d targetOrientation;
-targetOrientation << 1.0, 0.0, 0.0, 0.0;
-geometry_msgs::PoseStamped targetPoseStamped;
+  double dt = motionPrimitives_.at(motion_selector_).getsamplingTime();
+  int N = motionPrimitives_.at(motion_selector_).getDuration()/dt; //Resolution of the trajectory to be published
+  double theta;
+  Eigen::Vector3d targetPosition;
+  Eigen::Vector4d targetOrientation;
+  targetOrientation << 1.0, 0.0, 0.0, 0.0;
+  geometry_msgs::PoseStamped targetPoseStamped;
 
-refTrajectory_.header.stamp = ros::Time::now();
-refTrajectory_.header.frame_id = 1;
+  refTrajectory_.header.stamp = ros::Time::now();
+  refTrajectory_.header.frame_id = 1;
 
-for(int i = 0 ; i < N ; i++){
-  theta = 2 * 3.141592 *((double) i / (double) N);
-  this->setTrajectoryTheta(theta);
-  this->moveReference();
-  targetPosition = this->getTargetPosition();
-  targetPoseStamped = vector3d2PoseStampedMsg(targetPosition, targetOrientation);
-  refTrajectory_.poses.push_back(targetPoseStamped);
-}
+  for(int i = 0 ; i < N ; i++){
+    targetPosition = motionPrimitives_.at(motion_selector_).getPosition(i*dt);
+    targetPoseStamped = vector3d2PoseStampedMsg(targetPosition, targetOrientation);
+    refTrajectory_.poses.push_back(targetPoseStamped);
+  }
 }
 
 void trajectoryPublisher::pubrefState(){


### PR DESCRIPTION
This PR implements a motion selector, in which when a primitive is selected, a reference is published along the primitive trajectory.

The trajectory publisher subscribes to the `/mavros/local_position/pose` and `/mavros/local_position/velocity` topics so that the primitives can be generated based on the position and velocity of the current state.
