### PR TITLE
minimum time primitive based on jerk

### DIFF
--- a/trajectory_publisher/include/trajectory_publisher/trajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectory.h
@@ -22,7 +22,7 @@ class trajectory {
     double T_;
     int type_;
     int target_trajectoryID_;
-    Eigen::Vector3d c_x_, c_y_, c_z_; //Coefficients for polynomial representation
+    Eigen::Vector4d c_x_, c_y_, c_z_; //Coefficients for polynomial representation
     Eigen::Vector3d traj_axis_;
     Eigen::Vector3d target_initpos;
     double traj_radius_, traj_omega_;
@@ -33,7 +33,8 @@ public:
     trajectory(int type);
     ~trajectory();
     void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel);
-    void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc);
+    void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d jerk);
+    void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc, Eigen::Vector3d jerk);
     void setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorXd &y_coefficients, Eigen::VectorXd &z_coefficients);
     void setTrajectory(int ID);
     void setTrajectory(int ID, double omega, Eigen::Vector3d axis, double radius, Eigen::Vector3d initpos);

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -50,6 +50,7 @@ private:
   double primitive_duration_;
   double trigger_time_;
   double init_pos_x_, init_pos_y_, init_pos_z_;
+  double max_jerk_;
   int num_primitives_;
   int motion_selector_;
 

--- a/trajectory_publisher/src/trajectory.cpp
+++ b/trajectory_publisher/src/trajectory.cpp
@@ -7,15 +7,15 @@
 trajectory::trajectory(int type) :
   N(0),
   dt_(0.1),
-  T_(10.0),
+  T_(1.0),
   type_(type) {
 
   traj_axis_ << 0.0, 0.0, 1.0;
   target_initpos << 0.0, 0.0, 0.0;
 
-  c_x_ << 0.0, 0.0, 0.0;
-  c_y_ << 0.0, 0.0, 0.0;
-  c_z_ << 0.0, 0.0, 0.0;
+  c_x_ << 0.0, 0.0, 0.0, 0.0;
+  c_y_ << 0.0, 0.0, 0.0, 0.0;
+  c_z_ << 0.0, 0.0, 0.0, 0.0;
 
 }
 
@@ -43,7 +43,27 @@ void trajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel){
 
 }
 
-void trajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc){
+void trajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d jerk){
+  //Generate primitives based on current state for smooth trajectory
+  c_x_(0) = pos(0);
+  c_y_(0) = pos(1);
+  c_z_(0) = pos(2);
+
+  c_x_(1) = vel(0);
+  c_y_(1) = vel(1);
+  c_z_(1) = vel(2);
+
+  c_x_(2) = 0.0; //Acceleration is neglected
+  c_y_(2) = 0.0;
+  c_z_(2) = 0.0;
+
+  c_x_(3) = jerk(0);
+  c_y_(3) = jerk(1);
+  c_z_(3) = jerk(2);
+
+}
+
+void trajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc, Eigen::Vector3d jerk){
   //Generate primitives based on current state for smooth trajectory
   c_x_(0) = pos(0);
   c_y_(0) = pos(1);
@@ -56,6 +76,10 @@ void trajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Ei
   c_x_(2) = acc(0);
   c_y_(2) = acc(1);
   c_z_(2) = acc(2);
+
+  c_x_(3) = jerk(0);
+  c_y_(3) = jerk(1);
+  c_z_(3) = jerk(2);
 
 }
 
@@ -81,9 +105,9 @@ Eigen::Vector3d trajectory::getPosition(double time){
       position << 0.0, 0.0, 0.0;
       break;
     case TRAJ_POLYNOMIAL :
-      position << c_x_(0) + c_x_(1) * (double) time + c_x_(2) * pow((double) time, 2) + c_x_(3) * pow((double) time, 3),
-              c_y_(0) + c_y_(1) * (double) time + c_y_(2) * pow((double) time, 2) + c_y_(3) * pow((double) time, 3),
-              c_z_(0) + c_z_(1) * (double) time + c_z_(2) * pow((double) time, 2) + c_z_(3) * pow((double) time, 3);
+      position << c_x_(0) + c_x_(1) * time + c_x_(2) * pow(time, 2) + c_x_(3) * pow(time, 3),
+              c_y_(0) + c_y_(1) * time + c_y_(2) * pow(time, 2) + c_y_(3) * pow(time, 3),
+              c_z_(0) + c_z_(1) * time + c_z_(2) * pow(time, 2) + c_z_(3) * pow(time, 3);
       break;
     case TRAJ_CIRCLE :
 

--- a/trajectory_publisher/src/trajectoryPublisher.cpp
+++ b/trajectory_publisher/src/trajectoryPublisher.cpp
@@ -28,17 +28,22 @@ trajectoryPublisher::trajectoryPublisher(const ros::NodeHandle& nh, const ros::N
   nh_.param<double>("/trajectory_publisher/initpos_z", init_pos_z_, 1.0);
   nh_.param<double>("/trajectory_publisher/updaterate", controlUpdate_dt_, 0.01);
   nh_.param<double>("/trajectory_publisher/horizon", primitive_duration_, 1.0);
-  nh_.param<int>("/trajectory_publisher/number_of_primitives", num_primitives_, 3);
-  nh_.param<int>("/trajectory_publisher/number_of_primitives", num_primitives_, 3);
-
-
-//  motionPrimitives_.resize(num_primitives_ );
-  for(int i = 0;  i < num_primitives_; i++) motionPrimitives_.emplace_back(TRAJ_POLYNOMIAL);
+  nh_.param<double>("/trajectory_publisher/maxjerk", max_jerk_, 10.0);
+  nh_.param<int>("/trajectory_publisher/number_of_primitives", num_primitives_, 7);
 
   inputs_.resize(num_primitives_);
-  inputs_.at(0) << 0.0, 0.0, 0.0;
-  inputs_.at(1) << 1.0, 1.0, 0.0;
-  inputs_.at(2) << -1.0, 1.0, 0.0;
+  inputs_.at(0) << 0.0, 0.0, 0.0; //Constant jerk inputs for minimim time trajectories
+  inputs_.at(1) << 1.0, 0.0, 0.0;
+  inputs_.at(2) << -1.0, 0.0, 0.0;
+  inputs_.at(3) << 0.0, 1.0, 0.0;
+  inputs_.at(4) << 0.0, -1.0, 0.0;
+  inputs_.at(5) << 0.0, 0.0, 1.0;
+  inputs_.at(6) << 0.0, 0.0, -1.0;
+
+  for(int i = 0;  i < num_primitives_; i++){
+    motionPrimitives_.emplace_back(TRAJ_POLYNOMIAL);
+    inputs_.at(i) = inputs_.at(i) * max_jerk_;
+  }
 
   initializePrimitives();
 


### PR DESCRIPTION
This PR redefines the motion primitive based on constant jerk.

Having constant jerk primitive is advantageous as it represents a minimum time trajectory based on bang bang control on jerk. 