### PR TITLE
Get rid of unused mav_msgs

### DIFF
--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -14,7 +14,6 @@
 #include <sstream>
 
 #include <Eigen/Dense>
-#include <mav_msgs/Actuators.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Twist.h>
 #include <geometry_msgs/TwistStamped.h>

--- a/geometric_controller/package.xml
+++ b/geometric_controller/package.xml
@@ -53,7 +53,6 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>catkin_simple</build_depend>
   <build_depend>nav_msgs</build_depend>
-  <build_depend>mav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>controller_msgs</build_depend>
   <build_depend>tf</build_depend>

--- a/trajectory_publisher/package.xml
+++ b/trajectory_publisher/package.xml
@@ -55,7 +55,6 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>kindr</build_depend>
   <build_depend>mav_planning_msgs</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>

--- a/trajectory_publisher/package.xml
+++ b/trajectory_publisher/package.xml
@@ -53,7 +53,6 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>catkin_simple</build_depend>
   <build_depend>nav_msgs</build_depend>
-  <build_depend>mav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>kindr</build_depend>


### PR DESCRIPTION
`mav_msgs` is currently not used in the package. Getting rid of unneeded dependency