### PR TITLE
Remove gcs_url from launch files

### DIFF
--- a/geometric_controller/launch/dob_track_circle.launch
+++ b/geometric_controller/launch/dob_track_circle.launch
@@ -1,7 +1,6 @@
 <launch>
   <arg name="mav_name" default="iris"/>
   <arg name="fcu_url" default="udp://:14540@127.0.0.1:14557"/>
-  <arg name="gcs_url" default="udp://:14550@127.0.0.1:14550"/>
   <arg name="tgt_system" default="1" />
   <arg name="tgt_component" default="1" />
   <arg name="command_input" default="2" />
@@ -31,7 +30,6 @@
 
   <node name="mavros" pkg="mavros" type="mavros_node" output="screen">
       <param name="fcu_url" value="$(arg fcu_url)" />
-      <param name="gcs_url" value="$(arg gcs_url)" />
       <param name="target_system_id" value="$(arg tgt_system)" />
       <param name="target_component_id" value="$(arg tgt_component)" />
       <!-- enable heartbeat send and reduce timeout -->

--- a/geometric_controller/launch/trajectory_controller.launch
+++ b/geometric_controller/launch/trajectory_controller.launch
@@ -1,7 +1,6 @@
 <launch>
   <arg name="mav_name" default="iris"/>
   <arg name="fcu_url" default="udp://:14540@127.0.0.1:14557"/>
-  <arg name="gcs_url" default="udp://:14550@127.0.0.1:14550"/>
   <arg name="tgt_system" default="1" />
   <arg name="tgt_component" default="1" />
   <arg name="command_input" default="2" />
@@ -20,7 +19,6 @@
 
   <node name="mavros" pkg="mavros" type="mavros_node" output="screen">
       <param name="fcu_url" value="$(arg fcu_url)" />
-      <param name="gcs_url" value="$(arg gcs_url)" />
       <param name="target_system_id" value="$(arg tgt_system)" />
       <param name="target_component_id" value="$(arg tgt_component)" />
       <!-- enable heartbeat send and reduce timeout -->

--- a/geometric_controller/launch/trajectory_track_circle.launch
+++ b/geometric_controller/launch/trajectory_track_circle.launch
@@ -1,7 +1,6 @@
 <launch>
   <arg name="mav_name" default="iris"/>
   <arg name="fcu_url" default="udp://:14540@127.0.0.1:14557"/>
-  <arg name="gcs_url" default="udp://:14550@127.0.0.1:14550"/>
   <arg name="tgt_system" default="1" />
   <arg name="tgt_component" default="1" />
   <arg name="command_input" default="2" />
@@ -30,7 +29,6 @@
 
   <node name="mavros" pkg="mavros" type="mavros_node" output="screen">
       <param name="fcu_url" value="$(arg fcu_url)" />
-      <param name="gcs_url" value="$(arg gcs_url)" />
       <param name="target_system_id" value="$(arg tgt_system)" />
       <param name="target_component_id" value="$(arg tgt_component)" />
       <!-- enable heartbeat send and reduce timeout -->


### PR DESCRIPTION
This PR removes `gcs_url` due to the recent updates from mavros as pointed out by @marcusabate in #41 