### PR TITLE
Add mavros_msgs as dependency

### DIFF
--- a/geometric_controller/package.xml
+++ b/geometric_controller/package.xml
@@ -56,6 +56,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>controller_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>mavros_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
@@ -66,6 +67,8 @@
   <run_depend>nav_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>mavros</run_depend>
+  <run_depend>mavros_msgs</run_depend>
+
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/trajectory_publisher/package.xml
+++ b/trajectory_publisher/package.xml
@@ -57,6 +57,7 @@
   <build_depend>tf</build_depend>
   <build_depend>mav_planning_msgs</build_depend>
   <build_depend>controller_msgs</build_depend>
+  <build_depend>mavros_msgs</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>catkin_simple</run_depend>
@@ -65,6 +66,7 @@
   <run_depend>nav_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>mav_planning_msgs</run_depend>
+  <run_depend>mavros_msgs</run_depend>
 
 
 


### PR DESCRIPTION
This caused a regression on causing a build error on certain systems
```
Errors     << geometric_controller:make /home/jalim/catkin_ws/logs/geometric_controller/build.make.003.log
In file included from /home/jalim/catkin_ws/src/mavros_controllers/geometric_controller/src/geometric_controller.cpp:3:0:
/home/jalim/catkin_ws/src/mavros_controllers/geometric_controller/include/geometric_controller/geometric_controller.h:23:33: fatal error: mavros_msgs/SetMode.h: No such file or directory
compilation terminated.
In file included from /home/jalim/catkin_ws/src/mavros_controllers/geometric_controller/src/geometric_controller_node.cpp:3:0:
/home/jalim/catkin_ws/src/mavros_controllers/geometric_controller/include/geometric_controller/geometric_controller.h:23:33: fatal error: mavros_msgs/SetMode.h: No such file or directory

```