### PR TITLE
Implement command input feedthrough

### DIFF
--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -53,7 +53,7 @@ class geometricCtrl
     ros::Time last_request_, reference_request_now_, reference_request_last_;
 
     string mav_name_;
-    bool fail_detec_, ctrl_enable_;
+    bool fail_detec_, ctrl_enable_, feedthrough_enable_;
     int ctrl_mode_;
     bool landing_commanded_;
     bool use_gzstates_, sim_enable_, use_dob_;
@@ -108,6 +108,9 @@ class geometricCtrl
     Eigen::Vector3d disturbanceobserver(Eigen::Vector3d pos_error, Eigen::Vector3d acc_setpoint);
     Eigen::Vector4d quatMultiplication(Eigen::Vector4d &q, Eigen::Vector4d &p);
     Eigen::Vector4d attcontroller(Eigen::Vector4d &ref_att, Eigen::Vector3d &ref_acc, Eigen::Vector4d &curr_att);
+    void getStates(Eigen::Vector3d &pos, Eigen::Vector4d &att, Eigen::Vector3d &vel, Eigen::Vector3d &angvel);
+    void setBodyRateCommand(Eigen::Vector4d bodyrate_command);
+    void setFeedthrough(bool feed_through);
     virtual ~ geometricCtrl();
 };
 


### PR DESCRIPTION
This PR implements a feedthrough mode where the geometric controller is disabled and a feedthrough input is provided.

This behavior is useful when deveopling new controllers, as a feedthrough control can be enabled / disabled while the geometric controller can be used as a fall back or hovering controller before the testing. 

For example, declare the controller as a object in your hearder file `.h`
```
geometricCtrl geometric_controller_;
```
And when exectuting the command in your executable `.cpp`, you can enable feedthrough for testing your controller, and disable the feedthrough otherwise
```
while(true){
    if(ctrl_mode_){
        geometric_controller_.setFeedthrough(true);
        geometric_controller_.setBodyRateCommand(cmdBodyRate_);
    } else {
        geometric_controller_.setFeedthrough(false);
   }
} 
```