### PR TITLE
Test setpoint raw message directly to mavros

### DIFF
--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -16,11 +16,15 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <std_srvs/SetBool.h>
 #include <nav_msgs/Path.h>
+#include <mavros_msgs/PositionTarget.h>
 #include <mav_planning_msgs/PolynomialTrajectory4D.h>
 #include "controller_msgs/FlatTarget.h"
 #include "trajectory_publisher/trajectory.h"
 #include "trajectory_publisher/polynomialtrajectory.h"
 #include "trajectory_publisher/shapetrajectory.h"
+
+#define REF_TWIST 8
+#define REF_SETPOINTRAW 16
 
 using namespace std;
 using namespace Eigen;
@@ -32,6 +36,7 @@ private:
   ros::Publisher trajectoryPub_;
   ros::Publisher referencePub_;
   ros::Publisher flatreferencePub_;
+  ros::Publisher rawreferencePub_;
   std::vector<ros::Publisher> primitivePub_;
   ros::Subscriber motionselectorSub_;
   ros::Subscriber mavposeSub_;
@@ -43,8 +48,6 @@ private:
 
   nav_msgs::Path refTrajectory_;
   nav_msgs::Path primTrajectory_;
-  geometry_msgs::TwistStamped refState_;
-  controller_msgs::FlatTarget flatrefState_;
 
   int trajectory_type_;
   Eigen::Vector3d p_targ, v_targ, a_targ;
@@ -57,7 +60,7 @@ private:
   double trigger_time_;
   double init_pos_x_, init_pos_y_, init_pos_z_;
   double max_jerk_;
-  int flatref_type_;
+  int pubreference_type_;
   int num_primitives_;
   int motion_selector_;
 
@@ -72,6 +75,7 @@ public:
   void pubprimitiveTrajectory();
   void pubrefState();
   void pubflatrefState();
+  void pubrefSetpointRaw();
   void initializePrimitives(int type);
   void updatePrimitives();
   void loopCallback(const ros::TimerEvent& event);

--- a/trajectory_publisher/launch/trajectory_setpointraw.launch
+++ b/trajectory_publisher/launch/trajectory_setpointraw.launch
@@ -10,15 +10,15 @@
   <arg name="log_output" default="screen" />
   <arg name="fcu_protocol" default="v2.0" />
   <arg name="respawn_mavros" default="false" />
-  
+
   <node pkg="geometric_controller" type="geometric_controller_node" name="geometric_controller" output="screen">
   		<param name="mav_name" type="string" value="$(arg mav_name)" />
-          <remap from="command/bodyrate_command" to="/mavros/setpoint_raw/attitude"/>
           <param name="ctrl_mode" value="$(arg command_input)" />
           <param name="enable_sim" value="$(arg gazebo_simulation)" />
           <param name="enable_gazebo_state" value="true"/>
   </node>
 
+  
   <node pkg="trajectory_publisher" type="trajectory_publisher" name="trajectory_publisher" output="screen">
         <param name="trajectory_type" value="1" />
         <param name="shape_omega" value="1.2" />
@@ -27,7 +27,7 @@
         <param name="Kpos_x" value="8.0" />
         <param name="Kpos_y" value="8.0" />
         <param name="Kpos_z" value="30.0" />
-        <param name="reference_type" value="2" />
+        <param name="reference_type" value="16" />
   </node>
 
   <include file="$(find mavros)/launch/node.launch">

--- a/trajectory_publisher/src/trajectoryPublisher.cpp
+++ b/trajectory_publisher/src/trajectoryPublisher.cpp
@@ -14,7 +14,7 @@ trajectoryPublisher::trajectoryPublisher(const ros::NodeHandle& nh, const ros::N
   trajectoryPub_ = nh_.advertise<nav_msgs::Path>("/trajectory_publisher/trajectory", 1);
   referencePub_ = nh_.advertise<geometry_msgs::TwistStamped>("reference/setpoint", 1);
   flatreferencePub_ = nh_.advertise<controller_msgs::FlatTarget>("reference/flatsetpoint", 1);
-  rawreferencePub_ = nh_.advertise<mavros_msgs::PositionTarget>("/mavros/setpoint_raw/target_local", 1);
+  rawreferencePub_ = nh_.advertise<mavros_msgs::PositionTarget>("/mavros/setpoint_raw/local", 1);
   motionselectorSub_ = nh_.subscribe("/trajectory_publisher/motionselector", 1, &trajectoryPublisher::motionselectorCallback, this,ros::TransportHints().tcpNoDelay());
   mavposeSub_ = nh_.subscribe("/mavros/local_position/pose", 1, &trajectoryPublisher::mavposeCallback, this,ros::TransportHints().tcpNoDelay());
   mavtwistSub_ = nh_.subscribe("/mavros/local_position/velocity", 1, &trajectoryPublisher::mavtwistCallback, this,ros::TransportHints().tcpNoDelay());
@@ -161,8 +161,7 @@ void trajectoryPublisher::pubrefSetpointRaw(){
   msg.position.z = p_targ(2);
   msg.velocity.x = v_targ(0);
   msg.velocity.y = v_targ(1);
-  msg.velocity.z = v_targ(2);  
-
+  msg.velocity.z = v_targ(2);
   rawreferencePub_.publish(msg);
 }
 
@@ -187,11 +186,7 @@ void trajectoryPublisher::refCallback(const ros::TimerEvent& event){
     default : 
       pubflatrefState();
       break;
-
   }
-
-  // if(flatref_type_== 0) pubflatrefState();
-  // else pubrefState();
 }
 
 bool trajectoryPublisher::triggerCallback(std_srvs::SetBool::Request &req,


### PR DESCRIPTION
This PR enable strajectory publisher to directly publish `setpoint_raw` message for the feedforward message

Fixes #39 