### PR TITLE
add eigen dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 # Artifacts from clion
 */cmake-build-debug/*
+
+#Artifacts from vscode
+.vscode/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,6 @@ install:
 # wstool looks for a ROSINSTALL_FILE defined in the environment variables.
 before_script:
   # source dependencies: install using wstool.
-  - sudo ln -s /usr/include/eigen3/Eigen /usr/local/include/Eigen
   - cd ~/catkin_ws
   - wstool init src
   # - rosinstall_generator --rosdistro kinetic mavlink | tee /tmp/mavros.rosinstall

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,2 +1,3 @@
 - git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple.git'}
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}
+- git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin'}

--- a/geometric_controller/package.xml
+++ b/geometric_controller/package.xml
@@ -19,7 +19,7 @@
   <build_depend>controller_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>mavros_msgs</build_depend>
-
+  <build_depend> eigen_catkin</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>catkin_simple</run_depend>


### PR DESCRIPTION
I faced an issue as follows;

~/catkin_ws/src/mavros_controllers/geometric_controller/include/geometric_controller/geometric_controller.h:16:23: fatal error: Eigen/Dense: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/geometric_controller.dir/src/geometric_controller.cpp.o] Error 1
make[1]: *** [CMakeFiles/geometric_controller.dir/all] Error 2
make: *** [all] Error 2

and resolved with this commit. You will need to have https://github.com/ethz-asl/eigen_catkin as well.