### PR TITLE
Add parameter in launchfile to enable other PX4 SITL models

### DIFF
--- a/geometric_controller/launch/trajectory_track_circle.launch
+++ b/geometric_controller/launch/trajectory_track_circle.launch
@@ -43,7 +43,10 @@
       <arg name="respawn_mavros" default="$(arg respawn_mavros)" />
   </include>
 
-  <include file="$(find px4)/launch/posix_sitl.launch"/>
+  <include file="$(find px4)/launch/posix_sitl.launch">
+      <arg name="vehicle" value="$(arg mav_name)"/>
+  </include>
+
   <group if="$(arg visualization)">
       <node type="rviz" name="rviz" pkg="rviz" args="-d $(find geometric_controller)/launch/config_file.rviz" />
   </group>

--- a/trajectory_publisher/launch/trajectory_setpointraw.launch
+++ b/trajectory_publisher/launch/trajectory_setpointraw.launch
@@ -43,7 +43,10 @@
       <arg name="respawn_mavros" default="$(arg respawn_mavros)" />
   </include>
 
-  <include file="$(find px4)/launch/posix_sitl.launch"/>
+  <include file="$(find px4)/launch/posix_sitl.launch">
+      <arg name="vehicle" value="$(arg mav_name)"/>
+  </include>
+  
   <group if="$(arg visualization)">
       <node type="rviz" name="rviz" pkg="rviz" args="-d $(find geometric_controller)/launch/config_file.rviz" />
   </group>


### PR DESCRIPTION
Just played around to find out that VTOL airframes also support offboard mode.

This is sort of a side effect of the VTOL attitude control using both fixed wing and multirotor controllers together. 
Changing the `mav_name` to SITL targets such as `tailsitter` / `standard_vtol` as well as other models such as `iris_optflow` will spawn different models in the SITL simulation.

Here is a standard vtol following `setpoint_raw` topics run by the following command: 

```
roslaunch trajectory_publisher trajectory_setpointraw.launch
```

[![VTOL](https://img.youtube.com/vi/6dLV01W0uEc/0.jpg)](https://youtu.be/6dLV01W0uEc "VTOL")


