### PR TITLE
Bring back auto arming for simulation flag

### DIFF
--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -109,7 +109,7 @@ class geometricCtrl
     geometry_msgs::PoseStamped vector3d2PoseStampedMsg(Eigen::Vector3d &position, Eigen::Vector4d &orientation);
 
     enum FlightState {
-      WAITING_FOR_HOME_POSE, WAITING_TO_BE_ARMED, MISSION_EXECUTION, LANDING, LANDED
+      WAITING_FOR_HOME_POSE, MISSION_EXECUTION, LANDING, LANDED
     } node_state;
 
     template <class T>

--- a/geometric_controller/src/geometric_controller.cpp
+++ b/geometric_controller/src/geometric_controller.cpp
@@ -226,17 +226,9 @@ void geometricCtrl::cmdloopCallback(const ros::TimerEvent& event){
       node_state = MISSION_EXECUTION;
       break;
   case MISSION_EXECUTION:
-    //TODO: Enable Failsaif sutdown
-    if(ctrl_mode_ == MODE_ROTORTHRUST){
-      //TODO: Compute Thrust commands
-    } else if(ctrl_mode_ == MODE_BODYRATE){
-        if(!feedthrough_enable_) computeBodyRateCmd(false);
-        pubReferencePose();
-        pubRateCommands();
-    } else if(ctrl_mode_ == MODE_BODYTORQUE){
-      //TODO: implement actuator commands for mavros
-    }
-    ros::spinOnce();
+    if(!feedthrough_enable_)  computeBodyRateCmd(false);
+    pubReferencePose();
+    pubRateCommands();
     break;
   case LANDING: {
     geometry_msgs::PoseStamped landingmsg;


### PR DESCRIPTION
This PR brings back the autoarming sequence if the simulation flag is enabled.

This is done by modifying the logic proposed by #59 . In my opinion, this is safer as arming should be the last thing done before the drone flies. (before mode change to offboard mode) However, offboard mode can only be entered in the `MISSION_EXECUTION` state.

Therefore, the logic was changed 
from `WAITING_FOR_HOME_POSE` -> `WATING_TO_BE_ARMED` -> `MISSION_EXECUTION`
to `WAITING_FOR_HOME_POSE`  -> `MISSION_EXECUTION`

@marcusabate It would be great if you can provide feedback on this change

