### PR TITLE
Enable velocity heading

### DIFF
--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -59,6 +59,7 @@ class geometricCtrl
     int ctrl_mode_;
     bool landing_commanded_;
     bool sim_enable_, use_dob_;
+    bool velocity_yaw_;
     double kp_rot_, kd_rot_;
     double reference_request_dt_;
     double attctrl_tau_;

--- a/geometric_controller/src/geometric_controller.cpp
+++ b/geometric_controller/src/geometric_controller.cpp
@@ -35,7 +35,7 @@ geometricCtrl::geometricCtrl(const ros::NodeHandle& nh, const ros::NodeHandle& n
   nh_.param<string>("/geometric_controller/mavname", mav_name_, "iris");
   nh_.param<int>("/geometric_controller/ctrl_mode", ctrl_mode_, MODE_BODYRATE);
   nh_.param<bool>("/geometric_controller/enable_sim", sim_enable_, true);
-  nh_.param<bool>("/geometric_controller/velocity_yaw", velocity_yaw_, true);
+  nh_.param<bool>("/geometric_controller/velocity_yaw", velocity_yaw_, false);
   nh_.param<double>("/geometric_controller/max_acc", max_fb_acc_, 7.0);
   nh_.param<double>("/geometric_controller/yaw_heading", mavYaw_, 0.0);
   nh_.param<double>("/geometric_controller/drag_dx", dx_, 0.0);

--- a/geometric_controller/src/geometric_controller.cpp
+++ b/geometric_controller/src/geometric_controller.cpp
@@ -35,6 +35,7 @@ geometricCtrl::geometricCtrl(const ros::NodeHandle& nh, const ros::NodeHandle& n
   nh_.param<string>("/geometric_controller/mavname", mav_name_, "iris");
   nh_.param<int>("/geometric_controller/ctrl_mode", ctrl_mode_, MODE_BODYRATE);
   nh_.param<bool>("/geometric_controller/enable_sim", sim_enable_, true);
+  nh_.param<bool>("/geometric_controller/velocity_yaw", velocity_yaw_, true);
   nh_.param<double>("/geometric_controller/max_acc", max_fb_acc_, 7.0);
   nh_.param<double>("/geometric_controller/yaw_heading", mavYaw_, 0.0);
   nh_.param<double>("/geometric_controller/drag_dx", dx_, 0.0);
@@ -334,7 +335,8 @@ Eigen::Vector4d geometricCtrl::acc2quaternion(Eigen::Vector3d vector_acc, double
   Eigen::Vector3d zb_des, yb_des, xb_des, proj_xb_des;
   Eigen::Matrix3d rotmat;
 
-  proj_xb_des << std::cos(yaw), std::sin(yaw), 0.0;
+  if(velocity_yaw_) proj_xb_des = targetVel_.normalized();
+  else proj_xb_des << std::cos(yaw), std::sin(yaw), 0.0;
   zb_des = vector_acc / vector_acc.norm();
   yb_des = zb_des.cross(proj_xb_des) / (zb_des.cross(proj_xb_des)).norm();
   xb_des = yb_des.cross(zb_des) / ( yb_des.cross(zb_des) ).norm();


### PR DESCRIPTION
@EdXian I have implemented a simple way of making the heading follow the velocity dynamically. This is a first step to address #64 

The attitude controller is still not reduced on the yaw axis, but it seems to handle large yaw errors.
This can be enabled by setting the parameter
```
/geometric_controller/velocity_yaw = true
```
The implementation can be found in the video below. 

[![Hovering done](https://img.youtube.com/vi/0XPdyFFL8C8/0.jpg)](https://youtu.be/0XPdyFFL8C8 "Hovering done")

I will also follow up where a yaw can be set independently with a topic 