### PR TITLE
IMPORTANT: Corrected sourcing of px4 sitl default. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ To source the PX4 environment, run the following commands
 
 ```bash
 cd <Firmware_directory>
-source ~/catkin_ws/devel/setup.bash    // (optional)
-source Tools/setup_gazebo.bash $(pwd) $(pwd)/build/posix_sitl_default
+source ~/catkin_ws/devel/setup.bash    # (optional)
+source Tools/setup_gazebo.bash $(pwd) $(pwd)/build/px4_sitl_default
 export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$(pwd)
 export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$(pwd)/Tools/sitl_gazebo
 ```
+
 You can run the rest of the roslaunch files in the same terminal
 
 ```bash


### PR DESCRIPTION
The correct file to source is **px4**_sitl_default and not **posix**_sitl_default. This mistake was introduced due to the differences between the [master](https://dev.px4.io/master/en/simulation/ros_interface.html) and [stable](https://dev.px4.io/en/simulation/ros_interface.html) versions of the documentation. Since for this repo, the mavros installation is from source, the master version is the one to follow.

I already tested this version and after "roslaunch geometric_controller sitl_trajectory_track_circle.launch" the drone effectively takes off and follows the circular trajectory.