### PR TITLE
Fine tune geometric controller for lamniscate trajectory

### DIFF
--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -84,7 +84,7 @@ class geometricCtrl
     double kp_rot_, kd_rot_;
     double reference_request_dt_;
     double attctrl_tau_;
-    double norm_thrust_const_;
+    double norm_thrust_const_, norm_thrust_offset_;
     double max_fb_acc_;
     double dx_, dy_, dz_;
 

--- a/geometric_controller/launch/sitl_trajectory_track_circle.launch
+++ b/geometric_controller/launch/sitl_trajectory_track_circle.launch
@@ -17,16 +17,16 @@
           <param name="ctrl_mode" value="$(arg command_input)" />
           <param name="enable_sim" value="$(arg gazebo_simulation)" />
           <param name="enable_gazebo_state" value="true"/>
+          <param name="max_acc" value="10.0" />
+          <param name="Kp_x" value="8.0" />
+          <param name="Kp_y" value="8.0" />
+          <param name="Kp_z" value="30.0" />
   </node>
 
   <node pkg="trajectory_publisher" type="trajectory_publisher" name="trajectory_publisher" output="screen">
         <param name="trajectory_type" value="1" />
         <param name="shape_omega" value="1.2" />
         <param name="initpos_z" value="2.0" />
-        <param name="max_acc" value="10.0" />
-        <param name="Kpos_x" value="8.0" />
-        <param name="Kpos_y" value="8.0" />
-        <param name="Kpos_z" value="30.0" />
         <param name="reference_type" value="2" />
   </node>
 

--- a/geometric_controller/launch/sitl_trajectory_track_lamniscate.launch
+++ b/geometric_controller/launch/sitl_trajectory_track_lamniscate.launch
@@ -1,0 +1,60 @@
+<launch>
+  <arg name="mav_name" default="iris"/>
+  <arg name="fcu_url" default="udp://:14540@127.0.0.1:14557"/>
+  <arg name="gcs_url" default="" />
+  <arg name="tgt_system" default="1" />
+  <arg name="tgt_component" default="1" />
+  <arg name="command_input" default="2" />
+  <arg name="gazebo_simulation" default="true" />
+  <arg name="visualization" default="true"/>
+  <arg name="log_output" default="screen" />
+  <arg name="fcu_protocol" default="v2.0" />
+  <arg name="respawn_mavros" default="false" />
+  
+  <node pkg="geometric_controller" type="geometric_controller_node" name="geometric_controller" output="screen">
+  		<param name="mav_name" type="string" value="$(arg mav_name)" />
+          <remap from="command/bodyrate_command" to="/mavros/setpoint_raw/attitude"/>
+          <param name="ctrl_mode" value="$(arg command_input)" />
+          <param name="enable_sim" value="$(arg gazebo_simulation)" />
+          <param name="enable_gazebo_state" value="true"/>
+          <param name="max_acc" value="20.0" />
+          <param name="Kp_x" value="12.0" />
+          <param name="Kp_y" value="12.0" />
+          <param name="Kp_z" value="10.0" />
+          <param name="Kv_x" value="3.0" />
+          <param name="Kv_y" value="3.0" />
+          <param name="Kv_z" value="3.3" />
+  </node>
+
+  <node pkg="trajectory_publisher" type="trajectory_publisher" name="trajectory_publisher" output="screen">
+        <param name="trajectory_type" value="2" />
+        <param name="shape_omega" value="1.2" />
+        <param name="initpos_z" value="2.0" />
+        <param name="reference_type" value="2" />
+  </node>
+
+  <!-- Launch rqt_reconfigure -->
+  <node pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen" name="rqt_reconfigure" />
+
+  <include file="$(find mavros)/launch/node.launch">
+      <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
+      <arg name="config_yaml" value="$(find mavros)/launch/px4_config.yaml" />
+
+      <arg name="fcu_url" value="$(arg fcu_url)" />
+      <arg name="gcs_url" value="$(arg gcs_url)" />
+      <arg name="tgt_system" value="$(arg tgt_system)" />
+      <arg name="tgt_component" value="$(arg tgt_component)" />
+      <arg name="log_output" value="$(arg log_output)" />
+      <arg name="fcu_protocol" value="$(arg fcu_protocol)" />
+      <arg name="respawn_mavros" default="$(arg respawn_mavros)" />
+  </include>
+
+  <include file="$(find px4)/launch/posix_sitl.launch">
+      <arg name="vehicle" value="$(arg mav_name)"/>
+  </include>
+
+  <group if="$(arg visualization)">
+      <node type="rviz" name="rviz" pkg="rviz" args="-d $(find geometric_controller)/launch/config_file.rviz" />
+  </group>
+
+</launch>

--- a/geometric_controller/src/geometric_controller.cpp
+++ b/geometric_controller/src/geometric_controller.cpp
@@ -38,13 +38,14 @@ geometricCtrl::geometricCtrl(const ros::NodeHandle& nh, const ros::NodeHandle& n
   nh_private_.param<int>("ctrl_mode", ctrl_mode_, MODE_BODYRATE);
   nh_private_.param<bool>("enable_sim", sim_enable_, true);
   nh_private_.param<bool>("velocity_yaw", velocity_yaw_, false);
-  nh_private_.param<double>("max_acc", max_fb_acc_, 7.0);
+  nh_private_.param<double>("max_acc", max_fb_acc_, 9.0);
   nh_private_.param<double>("yaw_heading", mavYaw_, 0.0);
   nh_private_.param<double>("drag_dx", dx_, 0.0);
   nh_private_.param<double>("drag_dy", dy_, 0.0);
   nh_private_.param<double>("drag_dz", dz_, 0.0);
   nh_private_.param<double>("attctrl_constant", attctrl_tau_, 0.1);
   nh_private_.param<double>("normalizedthrust_constant", norm_thrust_const_, 0.05); // 1 / max acceleration
+  nh_private_.param<double>("normalizedthrust_offset", norm_thrust_offset_, 0.1); // 1 / max acceleration
   nh_private_.param<double>("Kp_x", Kpos_x_, 8.0);
   nh_private_.param<double>("Kp_y", Kpos_y_, 8.0);
   nh_private_.param<double>("Kp_z", Kpos_z_, 10.0);
@@ -412,7 +413,7 @@ Eigen::Vector4d geometricCtrl::attcontroller(Eigen::Vector4d &ref_att, Eigen::Ve
   ratecmd(2) = (2.0 / attctrl_tau_) * std::copysign(1.0, qe(0)) * qe(3);
   rotmat = quat2RotMatrix(mavAtt_);
   zb = rotmat.col(2);
-  ratecmd(3) = std::max(0.0, std::min(1.0, norm_thrust_const_ * ref_acc.dot(zb))); //Calculate thrust
+  ratecmd(3) = std::max(0.0, std::min(1.0, norm_thrust_const_ * ref_acc.dot(zb) + norm_thrust_offset_)); //Calculate thrust
 
   return ratecmd;
 }

--- a/trajectory_publisher/src/shapetrajectory.cpp
+++ b/trajectory_publisher/src/shapetrajectory.cpp
@@ -91,6 +91,7 @@ Eigen::Vector3d shapetrajectory::getPosition(double time){
 Eigen::Vector3d shapetrajectory::getVelocity(double time){
 
   Eigen::Vector3d velocity;
+  double theta;
 
   switch(type_) {
     case TRAJ_CIRCLE :
@@ -99,6 +100,18 @@ Eigen::Vector3d shapetrajectory::getVelocity(double time){
       break;
     case TRAJ_STATIONARY :
 
+      velocity << 0.0, 0.0, 0.0;
+      break;
+
+    case TRAJ_LAMNISCATE : //Lemniscate of Genero
+
+      theta = traj_omega_* time;
+      velocity = -std::sin(theta) * traj_radial_
+                 + (std::pow(std::cos(theta), 2) - std::pow(std::sin(theta), 2)) * traj_axis_.cross(traj_radial_)
+                 + (1 + std::sin(theta)) * traj_axis_.dot(traj_radial_) * traj_axis_;
+      break;
+
+    default :
       velocity << 0.0, 0.0, 0.0;
       break;
   }
@@ -119,6 +132,10 @@ Eigen::Vector3d shapetrajectory::getAcceleration(double time){
 
       acceleration << 0.0, 0.0, 0.0;
       break;
+    default :
+      acceleration << 0.0, 0.0, 0.0;
+      break;
+
   }
   return acceleration;
 

--- a/trajectory_publisher/src/shapetrajectory.cpp
+++ b/trajectory_publisher/src/shapetrajectory.cpp
@@ -106,9 +106,9 @@ Eigen::Vector3d shapetrajectory::getVelocity(double time){
     case TRAJ_LAMNISCATE : //Lemniscate of Genero
 
       theta = traj_omega_* time;
-      velocity = -std::sin(theta) * traj_radial_
+      velocity = traj_omega_ * (-std::sin(theta) * traj_radial_
                  + (std::pow(std::cos(theta), 2) - std::pow(std::sin(theta), 2)) * traj_axis_.cross(traj_radial_)
-                 + (1 + std::sin(theta)) * traj_axis_.dot(traj_radial_) * traj_axis_;
+                 + (std::sin(theta)) * traj_axis_.dot(traj_radial_) * traj_axis_);
       break;
 
     default :


### PR DESCRIPTION
This PR is a fix for #99, where the `geometric_controller` seemed to be unable to track the lamniscate trajectory. It was resulting in higher altitudes and unable to properly track the position reference.

The fixes are as the following.
- Add velocity reference to the lamniscate trajectory
- Fine tune thrust scaling by adding offset (improves altitude control)
- Fix launchfile parameter mis-definitions: gains were defined in trajectory publsiher

I believe the trajectory tracking performance can be improved once we have acceleration reference for the lamniscate trajectory. This is now assumed to be zero, which results in overshooting the reference in high accelerations.

@SwiftGust  Could you try this out?