### PR TITLE
Add CI for github actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,41 @@
+
+name: Build Test
+on: [push]
+
+jobs:
+  kineticbuild:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-ros-kinetic:2019-10-24
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: release_build_test
+      working-directory: 
+      run: |
+        apt update
+        apt install -y python3-wstool
+        mkdir -p $HOME/catkin_ws/src;
+        cd $HOME/catkin_ws
+        catkin init
+        catkin config --extend "/opt/ros/kinetic"
+        catkin config --merge-devel
+        cd $HOME/catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd $HOME/catkin_ws
+        wstool init src src/mavros_controllers/dependencies.rosinstall
+        wstool update -t src -j4
+        rosdep update
+        rosdep install --from-paths src --ignore-src -y --rosdistro $ROS_DISTRO
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False
+        catkin build -j$(nproc) -l$(nproc) geometric_controller trajectory_publisher
+    - name: unit_tests
+      working-directory:
+      run: |
+        cd $HOME/catkin_ws/src
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True
+        catkin build geometric_controller trajectory_publisher --no-deps -v -i --catkin-make-args tests
+        source $HOME/catkin_ws/devel/setup.bash
+        status=0 && for f in $HOME/catkin_ws/devel/lib/*/*-test; do $f || exit 1; done
+      shell: bash

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,2 +1,3 @@
+- git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple'} 
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm'}
 - git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin'}

--- a/trajectory_publisher/CMakeLists.txt
+++ b/trajectory_publisher/CMakeLists.txt
@@ -11,9 +11,14 @@ find_package(catkin REQUIRED COMPONENTS
   mavros_extras
   mavros_msgs
   mavlink
+  controller_msgs
 )
 
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+include_directories(
+  include
+  ${Boost_INCLUDE_DIR}
+  ${catkin_INCLUDE_DIRS}
+)
 
 ############
 # BINARIES #
@@ -25,7 +30,7 @@ add_executable(trajectory_publisher
         src/polynomialtrajectory.cpp
         src/shapetrajectory.cpp
 )
-
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 ##########
 # EXPORT #

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -17,7 +17,6 @@
 #include <std_srvs/SetBool.h>
 #include <nav_msgs/Path.h>
 #include <mavros_msgs/PositionTarget.h>
-#include <mav_planning_msgs/PolynomialTrajectory4D.h>
 #include "controller_msgs/FlatTarget.h"
 #include "trajectory_publisher/trajectory.h"
 #include "trajectory_publisher/polynomialtrajectory.h"
@@ -81,7 +80,6 @@ public:
   void loopCallback(const ros::TimerEvent& event);
   void refCallback(const ros::TimerEvent& event);
   bool triggerCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
-  void trajectoryCallback(const mav_planning_msgs::PolynomialTrajectory4D& segments_message);
   void motionselectorCallback(const std_msgs::Int32& selector);
   void mavposeCallback(const geometry_msgs::PoseStamped& msg);
   void mavtwistCallback(const geometry_msgs::TwistStamped& msg);

--- a/trajectory_publisher/src/trajectoryPublisher.cpp
+++ b/trajectory_publisher/src/trajectoryPublisher.cpp
@@ -206,16 +206,6 @@ void trajectoryPublisher::motionselectorCallback(const std_msgs::Int32& selector
 
 }
 
-void trajectoryPublisher::trajectoryCallback(const mav_planning_msgs::PolynomialTrajectory4D& segments_msg) {
-
-  start_time_ = ros::Time::now();
-  //TODO: implement a trajectory replay functionality
-//  segments_message.segments;
-//
-//  motionPrimitives_.setPolynomial();
-
-}
-
 void trajectoryPublisher::mavposeCallback(const geometry_msgs::PoseStamped& msg){
 
   p_mav_(0) = msg.pose.position.x;


### PR DESCRIPTION
This PR adds Ci for github actions and removes travis from CI

The following improvements are included in this PR
- github actions are much faster than travis
- We use the px4 container so we don't need to install ROS every time we fire the CI
- Added unit tests as part of the CI checks