### PR TITLE
Fix issue can't locate node trajectory_publisher

### DIFF
--- a/trajectory_publisher/CMakeLists.txt
+++ b/trajectory_publisher/CMakeLists.txt
@@ -14,6 +14,11 @@ find_package(catkin REQUIRED COMPONENTS
   controller_msgs
 )
 
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp rospy std_msgs nav_msgs geometry_msgs tf mav_planning_msgs controller_msgs mavros_msgs
+)
+
 include_directories(
   include
   ${Boost_INCLUDE_DIR}

--- a/trajectory_publisher/package.xml
+++ b/trajectory_publisher/package.xml
@@ -33,7 +33,7 @@
   <run_depend>tf</run_depend>
   <run_depend>mav_planning_msgs</run_depend>
   <run_depend>mavros_msgs</run_depend>
-
+  <run_depend>controller_msgs</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
After building as follows README, found following issue.
ERROR: cannot launch node of type [trajectory_publisher/trajectory_publisher]: can't locate node [trajectory_publisher] in package [trajectory_publisher]

This patch solves this issue by adding catkin_package() macro to CMakeList.txt.
The issue found to be recent change in CMakeList.txt in trajectory_publisher where removed catkin_simple macros, it seems catkin_simple package have been doing this job automatically.

Issue found & solution tested on new ROS workspace

Before this fix
~/ctrl_ws/devel/lib$ ls
geometric_controller  libgeometric_controller.so  pkgconfig  python2.7

After this fix
~/ctrl_ws/devel/lib$ ls
geometric_controller  libgeometric_controller.so  pkgconfig  python2.7  trajectory_publisher