### PR TITLE
Add noetic builds for tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,6 +17,7 @@ jobs:
         config:
           - {rosdistro: 'kinetic', container: 'px4io/px4-dev-ros-kinetic:2020-07-18'} 
           - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-08-14'}
+          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-08-20'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Previously, catkin was broken on the ROS noetic container distributed from PX4. 

Since this was fixed in https://github.com/PX4/containers/pull/275, this PR adds ROS noetic to build tests.

@mzahana FYI
