### PR TITLE
Minor cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 format:
-	Tools/fix_style.sh geometric_controller/src
-	Tools/fix_style.sh trajectory_publisher/src
+	Tools/fix_code_style.sh geometric_controller/src
+	Tools/fix_code_style.sh trajectory_publisher/src

--- a/geometric_controller/include/geometric_controller/common.h
+++ b/geometric_controller/include/geometric_controller/common.h
@@ -1,0 +1,84 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <Eigen/Dense>
+
+static Eigen::Matrix3d matrix_hat(const Eigen::Vector3d &v) {
+  Eigen::Matrix3d m;
+  // Sanity checks on M
+  m << 0.0, -v(2), v(1), v(2), 0.0, -v(0), -v(1), v(0), 0.0;
+  return m;
+}
+
+static Eigen::Vector3d matrix_hat_inv(const Eigen::Matrix3d &m) {
+  Eigen::Vector3d v;
+  // TODO: Sanity checks if m is skew symmetric
+  v << m(7), m(2), m(3);
+  return v;
+}
+
+Eigen::Vector3d toEigen(const geometry_msgs::Point &p) {
+  Eigen::Vector3d ev3(p.x, p.y, p.z);
+  return ev3;
+}
+
+inline Eigen::Vector3d toEigen(const geometry_msgs::Vector3 &v3) {
+  Eigen::Vector3d ev3(v3.x, v3.y, v3.z);
+  return ev3;
+}
+
+Eigen::Vector4d quatMultiplication(const Eigen::Vector4d &q, const Eigen::Vector4d &p) {
+  Eigen::Vector4d quat;
+  quat << p(0) * q(0) - p(1) * q(1) - p(2) * q(2) - p(3) * q(3), p(0) * q(1) + p(1) * q(0) - p(2) * q(3) + p(3) * q(2),
+      p(0) * q(2) + p(1) * q(3) + p(2) * q(0) - p(3) * q(1), p(0) * q(3) - p(1) * q(2) + p(2) * q(1) + p(3) * q(0);
+  return quat;
+}
+
+Eigen::Matrix3d quat2RotMatrix(const Eigen::Vector4d &q) {
+  Eigen::Matrix3d rotmat;
+  rotmat << q(0) * q(0) + q(1) * q(1) - q(2) * q(2) - q(3) * q(3), 2 * q(1) * q(2) - 2 * q(0) * q(3),
+      2 * q(0) * q(2) + 2 * q(1) * q(3),
+
+      2 * q(0) * q(3) + 2 * q(1) * q(2), q(0) * q(0) - q(1) * q(1) + q(2) * q(2) - q(3) * q(3),
+      2 * q(2) * q(3) - 2 * q(0) * q(1),
+
+      2 * q(1) * q(3) - 2 * q(0) * q(2), 2 * q(0) * q(1) + 2 * q(2) * q(3),
+      q(0) * q(0) - q(1) * q(1) - q(2) * q(2) + q(3) * q(3);
+  return rotmat;
+}
+
+Eigen::Vector4d rot2Quaternion(const Eigen::Matrix3d &R) {
+  Eigen::Vector4d quat;
+  double tr = R.trace();
+  if (tr > 0.0) {
+    double S = sqrt(tr + 1.0) * 2.0;  // S=4*qw
+    quat(0) = 0.25 * S;
+    quat(1) = (R(2, 1) - R(1, 2)) / S;
+    quat(2) = (R(0, 2) - R(2, 0)) / S;
+    quat(3) = (R(1, 0) - R(0, 1)) / S;
+  } else if ((R(0, 0) > R(1, 1)) & (R(0, 0) > R(2, 2))) {
+    double S = sqrt(1.0 + R(0, 0) - R(1, 1) - R(2, 2)) * 2.0;  // S=4*qx
+    quat(0) = (R(2, 1) - R(1, 2)) / S;
+    quat(1) = 0.25 * S;
+    quat(2) = (R(0, 1) + R(1, 0)) / S;
+    quat(3) = (R(0, 2) + R(2, 0)) / S;
+  } else if (R(1, 1) > R(2, 2)) {
+    double S = sqrt(1.0 + R(1, 1) - R(0, 0) - R(2, 2)) * 2.0;  // S=4*qy
+    quat(0) = (R(0, 2) - R(2, 0)) / S;
+    quat(1) = (R(0, 1) + R(1, 0)) / S;
+    quat(2) = 0.25 * S;
+    quat(3) = (R(1, 2) + R(2, 1)) / S;
+  } else {
+    double S = sqrt(1.0 + R(2, 2) - R(0, 0) - R(1, 1)) * 2.0;  // S=4*qz
+    quat(0) = (R(1, 0) - R(0, 1)) / S;
+    quat(1) = (R(0, 2) + R(2, 0)) / S;
+    quat(2) = (R(1, 2) + R(2, 1)) / S;
+    quat(3) = 0.25 * S;
+  }
+  return quat;
+}
+
+#endif


### PR DESCRIPTION
**Problem Description**
The source code of `geometric_controller` has been growing, and is including a lot of functionalities. 

**Solution**
This PR includes the following cleanups while not touching the functionality of the package.
- Moves static math related functions to a header file, since it makes more sense to have it defined inline
- Fix return types for service callbacks
- Fix make file scripts since the script changed in #157 