### PR TITLE
Add back setDesiredAcceleration

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {rosdistro: 'kinetic', container: 'px4io/px4-dev-ros-kinetic:2020-07-18'} 
           - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-08-14'}
           - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-08-20'}
     container: ${{ matrix.config.container }}

--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -166,8 +166,8 @@ class geometricCtrl {
   bool landCallback(std_srvs::SetBool::Request &request, std_srvs::SetBool::Response &response);
   geometry_msgs::PoseStamped vector3d2PoseStampedMsg(Eigen::Vector3d &position, Eigen::Vector4d &orientation);
   void computeBodyRateCmd(Eigen::Vector4d &bodyrate_cmd, const Eigen::Vector3d &target_acc);
-  Eigen::Vector3d controlPosition(const Eigen::Vector3d &target_pos,
-                                                const Eigen::Vector3d &target_vel, const Eigen::Vector3d &target_acc);
+  Eigen::Vector3d controlPosition(const Eigen::Vector3d &target_pos, const Eigen::Vector3d &target_vel,
+                                  const Eigen::Vector3d &target_acc);
   Eigen::Vector3d poscontroller(const Eigen::Vector3d &pos_error, const Eigen::Vector3d &vel_error);
   Eigen::Vector4d attcontroller(const Eigen::Vector4d &ref_att, const Eigen::Vector3d &ref_acc,
                                 Eigen::Vector4d &curr_att);

--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -165,8 +165,9 @@ class geometricCtrl {
   bool ctrltriggerCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
   bool landCallback(std_srvs::SetBool::Request &request, std_srvs::SetBool::Response &response);
   geometry_msgs::PoseStamped vector3d2PoseStampedMsg(Eigen::Vector3d &position, Eigen::Vector4d &orientation);
-  void computeBodyRateCmd(Eigen::Vector4d &bodyrate_cmd, const Eigen::Vector3d &target_pos,
-                          const Eigen::Vector3d &target_vel, const Eigen::Vector3d &target_acc);
+  void computeBodyRateCmd(Eigen::Vector4d &bodyrate_cmd, const Eigen::Vector3d &target_acc);
+  Eigen::Vector3d controlPosition(const Eigen::Vector3d &target_pos,
+                                                const Eigen::Vector3d &target_vel, const Eigen::Vector3d &target_acc);
   Eigen::Vector3d poscontroller(const Eigen::Vector3d &pos_error, const Eigen::Vector3d &vel_error);
   Eigen::Vector4d attcontroller(const Eigen::Vector4d &ref_att, const Eigen::Vector3d &ref_acc,
                                 Eigen::Vector4d &curr_att);
@@ -205,6 +206,7 @@ class geometricCtrl {
   };
   void setBodyRateCommand(Eigen::Vector4d bodyrate_command) { cmdBodyRate_ = bodyrate_command; };
   void setFeedthrough(bool feed_through) { feedthrough_enable_ = feed_through; };
+  void setDesiredAcceleration(Eigen::Vector3d &acceleration) { targetAcc_ = acceleration; };
   static Eigen::Vector4d acc2quaternion(const Eigen::Vector3d &vector_acc, const double &yaw);
   static double getVelocityYaw(const Eigen::Vector3d velocity) { return atan2(velocity(1), velocity(0)); };
 };

--- a/geometric_controller/src/geometric_controller.cpp
+++ b/geometric_controller/src/geometric_controller.cpp
@@ -362,8 +362,8 @@ geometry_msgs::PoseStamped geometricCtrl::vector3d2PoseStampedMsg(Eigen::Vector3
   return encode_msg;
 }
 
-Eigen::Vector3d geometricCtrl::controlPosition(const Eigen::Vector3d &target_pos,
-                                               const Eigen::Vector3d &target_vel, const Eigen::Vector3d &target_acc) {
+Eigen::Vector3d geometricCtrl::controlPosition(const Eigen::Vector3d &target_pos, const Eigen::Vector3d &target_vel,
+                                               const Eigen::Vector3d &target_acc) {
   /// Compute BodyRate commands using differential flatness
   /// Controller based on Faessler 2017
   const Eigen::Vector3d a_ref = target_acc;


### PR DESCRIPTION
**Problem Description**
This PR adds back the `setDesiredAcceleration` interface to override the acceleration inputs by including the `geomtericCtrl` class as an object

**Additional Context**
- Need for fixing https://github.com/Jaeyoung-Lim/mav_dob/issues/3 @kimnerd FYI