### PR TITLE
Yaw in flat target.msg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 #Artifacts from vscode
 .vscode/*
+
+#Rviz config
+geometric_controller/launch/config_file.rviz

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@
 
 #Artifacts from vscode
 .vscode/*
-
-#Rviz config
-geometric_controller/launch/config_file.rviz

--- a/controller_msgs/msg/FlatTarget.msg
+++ b/controller_msgs/msg/FlatTarget.msg
@@ -7,6 +7,7 @@ uint8 type_mask
 uint8 IGNORE_SNAP = 1	# Position Velocity Acceleration Jerk Reference
 uint8 IGNORE_SNAP_JERK = 2	# Position Velocity Acceleration Reference
 uint8 IGNORE_SNAP_JERK_ACC = 4	# Position Reference
+uint8 IGNORE_YAW = 8 # Yaw Reference
 
 geometry_msgs/Vector3 position
 geometry_msgs/Vector3 velocity

--- a/controller_msgs/msg/FlatTarget.msg
+++ b/controller_msgs/msg/FlatTarget.msg
@@ -13,3 +13,4 @@ geometry_msgs/Vector3 velocity
 geometry_msgs/Vector3 acceleration
 geometry_msgs/Vector3 jerk
 geometry_msgs/Vector3 snap
+std_msgs/Float64 yaw

--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -60,6 +60,7 @@
 #include <mavros_msgs/State.h>
 #include <nav_msgs/Odometry.h>
 #include <nav_msgs/Path.h>
+#include <std_msgs/Float64.h>
 #include <std_msgs/Float32.h>
 #include <Eigen/Dense>
 

--- a/geometric_controller/src/geometric_controller.cpp
+++ b/geometric_controller/src/geometric_controller.cpp
@@ -147,6 +147,7 @@ void geometricCtrl::flattargetCallback(const controller_msgs::FlatTarget &msg) {
 
   targetPos_ = toEigen(msg.position);
   targetVel_ = toEigen(msg.velocity);
+  mavYaw_ = double(msg.yaw.data);
 
   if (msg.type_mask == 1) {
     targetAcc_ = toEigen(msg.acceleration);

--- a/geometric_controller/src/geometric_controller.cpp
+++ b/geometric_controller/src/geometric_controller.cpp
@@ -147,8 +147,11 @@ void geometricCtrl::flattargetCallback(const controller_msgs::FlatTarget &msg) {
 
   targetPos_ = toEigen(msg.position);
   targetVel_ = toEigen(msg.velocity);
-  mavYaw_ = double(msg.yaw.data);
-
+  if( (msg.type_mask & 8) == 8) // Ignore yaw
+     mavYaw_ = 0.0;
+  else
+    mavYaw_ = double(msg.yaw.data);
+   
   if (msg.type_mask == 1) {
     targetAcc_ = toEigen(msg.acceleration);
     targetJerk_ = toEigen(msg.jerk);

--- a/trajectory_publisher/include/trajectory_publisher/polynomialtrajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/polynomialtrajectory.h
@@ -59,6 +59,7 @@ class polynomialtrajectory : public trajectory {
   void setCoefficients(Eigen::VectorXd &x_coefficients, Eigen::VectorXd &y_coefficients,
                        Eigen::VectorXd &z_coefficients);
   Eigen::VectorXd getCoefficients(int dim);
+  float getYaw(double time);
   Eigen::Vector3d getPosition(double time);
   Eigen::Vector3d getVelocity(double time);
   Eigen::Vector3d getAcceleration(double time);

--- a/trajectory_publisher/include/trajectory_publisher/shapetrajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/shapetrajectory.h
@@ -65,6 +65,7 @@ class shapetrajectory : public trajectory {
   void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel);
   void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d jerk);
   void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc, Eigen::Vector3d jerk);
+  float getYaw(double time);
   Eigen::Vector3d getPosition(double time);
   Eigen::Vector3d getVelocity(double time);
   Eigen::Vector3d getAcceleration(double time);

--- a/trajectory_publisher/include/trajectory_publisher/trajectory.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectory.h
@@ -64,6 +64,7 @@ class trajectory {
   virtual void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d jerk) = 0;
   virtual void generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc,
                                   Eigen::Vector3d jerk) = 0;
+  virtual float getYaw(double time) = 0;
   virtual Eigen::Vector3d getPosition(double time) = 0;
   virtual Eigen::Vector3d getVelocity(double time) = 0;
   virtual Eigen::Vector3d getAcceleration(double time) = 0;

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -88,8 +88,8 @@ class trajectoryPublisher {
   nav_msgs::Path primTrajectory_;
 
   int trajectory_type_;
-  Eigen::Vector3d p_targ, v_targ, a_targ;
-  double yaw_targ;
+  Eigen::Vector3d p_targ_, v_targ_, a_targ_;
+  double yaw_targ_;
   Eigen::Vector3d p_mav_, v_mav_;
   Eigen::Vector3d shape_origin_, shape_axis_;
   double shape_omega_ = 0;
@@ -100,6 +100,7 @@ class trajectoryPublisher {
   double init_pos_x_, init_pos_y_, init_pos_z_;
   double max_jerk_;
   int pubreference_type_;
+  bool ignore_yaw_;
   int num_primitives_;
   int motion_selector_;
 

--- a/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
+++ b/trajectory_publisher/include/trajectory_publisher/trajectoryPublisher.h
@@ -53,6 +53,7 @@
 #include <nav_msgs/Path.h>
 #include <ros/ros.h>
 #include <std_msgs/Int32.h>
+#include <std_msgs/Float64.h>
 #include <std_msgs/String.h>
 #include <std_srvs/SetBool.h>
 #include "controller_msgs/FlatTarget.h"
@@ -88,6 +89,7 @@ class trajectoryPublisher {
 
   int trajectory_type_;
   Eigen::Vector3d p_targ, v_targ, a_targ;
+  double yaw_targ;
   Eigen::Vector3d p_mav_, v_mav_;
   Eigen::Vector3d shape_origin_, shape_axis_;
   double shape_omega_ = 0;

--- a/trajectory_publisher/src/polynomialtrajectory.cpp
+++ b/trajectory_publisher/src/polynomialtrajectory.cpp
@@ -129,9 +129,11 @@ Eigen::VectorXd polynomialtrajectory::getCoefficients(int dim) {
 }
 
 float polynomialtrajectory::getYaw(double time) {
-  float yaw = 0.0;
+  Eigen::Vector3d velocity = getVelocity(time); // Yaw is set in the direction of the vehicle
+  float yaw = atan2f(velocity(1),velocity(0));
   return yaw;
 }
+
 Eigen::Vector3d polynomialtrajectory::getPosition(double time) {
   Eigen::Vector3d position;
   position << c_x_(0) + c_x_(1) * time + c_x_(2) * pow(time, 2) + c_x_(3) * pow(time, 3),

--- a/trajectory_publisher/src/polynomialtrajectory.cpp
+++ b/trajectory_publisher/src/polynomialtrajectory.cpp
@@ -128,6 +128,10 @@ Eigen::VectorXd polynomialtrajectory::getCoefficients(int dim) {
   }
 }
 
+float polynomialtrajectory::getYaw(double time) {
+  float yaw = 0.0;
+  return yaw;
+}
 Eigen::Vector3d polynomialtrajectory::getPosition(double time) {
   Eigen::Vector3d position;
   position << c_x_(0) + c_x_(1) * time + c_x_(2) * pow(time, 2) + c_x_(3) * pow(time, 3),

--- a/trajectory_publisher/src/shapetrajectory.cpp
+++ b/trajectory_publisher/src/shapetrajectory.cpp
@@ -67,6 +67,25 @@ void shapetrajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d ve
 void shapetrajectory::generatePrimitives(Eigen::Vector3d pos, Eigen::Vector3d vel, Eigen::Vector3d acc,
                                          Eigen::Vector3d jerk) {}
 
+float shapetrajectory::getYaw(double time) {
+
+  float yaw;
+
+  switch (type_) {
+   
+    case TRAJ_ZERO:
+      yaw = 0;
+      break;
+
+    case TRAJ_CIRCLE:
+      yaw = (traj_omega_ * time) - M_PI; // always pointing to the center of the circle
+      yaw = atan2f( sin(yaw),cos(yaw) ); // wrap angle around [-pi,pi]
+      break;
+  }
+
+  return yaw;
+}
+
 Eigen::Vector3d shapetrajectory::getPosition(double time) {
   Eigen::Vector3d position;
   double theta;

--- a/trajectory_publisher/src/trajectoryPublisher.cpp
+++ b/trajectory_publisher/src/trajectoryPublisher.cpp
@@ -111,8 +111,9 @@ void trajectoryPublisher::updateReference() {
   curr_time_ = ros::Time::now();
   trigger_time_ = (curr_time_ - start_time_).toSec();
 
-  p_targ = motionPrimitives_.at(motion_selector_)->getPosition(trigger_time_);
-  v_targ = motionPrimitives_.at(motion_selector_)->getVelocity(trigger_time_);
+  p_targ   = motionPrimitives_.at(motion_selector_)->getPosition(trigger_time_);
+  v_targ   = motionPrimitives_.at(motion_selector_)->getVelocity(trigger_time_);
+  yaw_targ = motionPrimitives_.at(motion_selector_)->getYaw(trigger_time_);
   if (pubreference_type_ != 0) a_targ = motionPrimitives_.at(motion_selector_)->getAcceleration(trigger_time_);
 }
 
@@ -177,6 +178,7 @@ void trajectoryPublisher::pubflatrefState() {
   msg.acceleration.x = a_targ(0);
   msg.acceleration.y = a_targ(1);
   msg.acceleration.z = a_targ(2);
+  msg.yaw.data = yaw_targ;
   flatreferencePub_.publish(msg);
 }
 


### PR DESCRIPTION
Problem Description:

This PR adds yaw field to the FlatTarget.msg and any necessary modifications. The circle trajectory now sets yaw to point to the center of the circle at all time.

Additional Context:

This PR is related with #153.

To discuss:

1) The polynomial trajectory getYaw returns 0

```
float polynomialtrajectory::getYaw(double time) {
  float yaw = 0.0;
  return yaw;
}
```

2) Yaw is a float (Float32) not a double (Float64)