### PR TITLE
fix the compile bug

### DIFF
--- a/geometric_controller/CMakeLists.txt
+++ b/geometric_controller/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   mavros_extras
   mavros_msgs
   mavlink
+  controller_msgs
 )
 
 generate_dynamic_reconfigure_options(


### PR DESCRIPTION
I have a compile error in Ubuntu 20.04 ROS(noetic) and it will hint me the project haven't find out the `controller_msgs`, so I have checked that the `controller_msgs` has not added in the `find_package`.
