### PR TITLE
Abstract controllers into class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,2 @@
 format:
-	Tools/fix_code_style.sh geometric_controller/src
-	Tools/fix_code_style.sh trajectory_publisher/src
+	Tools/fix_code_style.sh .

--- a/geometric_controller/CMakeLists.txt
+++ b/geometric_controller/CMakeLists.txt
@@ -36,6 +36,9 @@ include_directories(
 
 add_library(${PROJECT_NAME}
   src/geometric_controller.cpp 
+  src/nonlinear_attitude_control.cpp
+  src/nonlinear_geometric_control.cpp
+  src/jerk_tracking_control.cpp
 )
 add_dependencies(geometric_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/geometric_controller/include/geometric_controller/common.h
+++ b/geometric_controller/include/geometric_controller/common.h
@@ -60,7 +60,7 @@ static Eigen::Vector3d matrix_hat_inv(const Eigen::Matrix3d &m) {
   return v;
 }
 
-Eigen::Vector3d toEigen(const geometry_msgs::Point &p) {
+inline Eigen::Vector3d toEigen(const geometry_msgs::Point &p) {
   Eigen::Vector3d ev3(p.x, p.y, p.z);
   return ev3;
 }
@@ -70,14 +70,14 @@ inline Eigen::Vector3d toEigen(const geometry_msgs::Vector3 &v3) {
   return ev3;
 }
 
-Eigen::Vector4d quatMultiplication(const Eigen::Vector4d &q, const Eigen::Vector4d &p) {
+inline Eigen::Vector4d quatMultiplication(const Eigen::Vector4d &q, const Eigen::Vector4d &p) {
   Eigen::Vector4d quat;
   quat << p(0) * q(0) - p(1) * q(1) - p(2) * q(2) - p(3) * q(3), p(0) * q(1) + p(1) * q(0) - p(2) * q(3) + p(3) * q(2),
       p(0) * q(2) + p(1) * q(3) + p(2) * q(0) - p(3) * q(1), p(0) * q(3) - p(1) * q(2) + p(2) * q(1) + p(3) * q(0);
   return quat;
 }
 
-Eigen::Matrix3d quat2RotMatrix(const Eigen::Vector4d &q) {
+inline Eigen::Matrix3d quat2RotMatrix(const Eigen::Vector4d &q) {
   Eigen::Matrix3d rotmat;
   rotmat << q(0) * q(0) + q(1) * q(1) - q(2) * q(2) - q(3) * q(3), 2 * q(1) * q(2) - 2 * q(0) * q(3),
       2 * q(0) * q(2) + 2 * q(1) * q(3),
@@ -90,7 +90,7 @@ Eigen::Matrix3d quat2RotMatrix(const Eigen::Vector4d &q) {
   return rotmat;
 }
 
-Eigen::Vector4d rot2Quaternion(const Eigen::Matrix3d &R) {
+inline Eigen::Vector4d rot2Quaternion(const Eigen::Matrix3d &R) {
   Eigen::Vector4d quat;
   double tr = R.trace();
   if (tr > 0.0) {

--- a/geometric_controller/include/geometric_controller/control.h
+++ b/geometric_controller/include/geometric_controller/control.h
@@ -1,0 +1,61 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018-2022 Jaeyoung Lim. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Controller base class
+ *
+ *
+ * @author Jaeyoung Lim <jalim@ethz.ch>
+ */
+
+#ifndef CONTROL_H
+#define CONTROL_H
+
+#include <Eigen/Dense>
+
+class Control {
+ public:
+  Control(){};
+  virtual ~Control(){};
+  virtual void Update(Eigen::Vector4d &curr_att, const Eigen::Vector4d &ref_att, const Eigen::Vector3d &ref_acc,
+                      const Eigen::Vector3d &ref_jerk){};
+  Eigen::Vector3d getDesiredThrust() { return desired_thrust_; };
+  Eigen::Vector3d getDesiredRate() { return desired_rate_; };
+  Eigen::Vector3d desired_rate_{Eigen::Vector3d::Zero()};
+  Eigen::Vector3d desired_thrust_{Eigen::Vector3d::Zero()};
+
+ protected:
+ private:
+};
+
+#endif

--- a/geometric_controller/include/geometric_controller/geometric_controller.h
+++ b/geometric_controller/include/geometric_controller/geometric_controller.h
@@ -126,7 +126,6 @@ class geometricCtrl {
   double dx_, dy_, dz_;
 
   mavros_msgs::State current_state_;
-  mavros_msgs::SetMode offb_set_mode_;
   mavros_msgs::CommandBool arm_cmd_;
   std::vector<geometry_msgs::PoseStamped> posehistory_vector_;
   MAV_STATE companion_state_ = MAV_STATE::MAV_STATE_ACTIVE;

--- a/geometric_controller/include/geometric_controller/jerk_tracking_control.h
+++ b/geometric_controller/include/geometric_controller/jerk_tracking_control.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018-2022 Jaeyoung Lim. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Controller base class
+ *
+ *
+ * @author Jaeyoung Lim <jalim@ethz.ch>
+ */
+
+#ifndef JERK_TRACKING_CONTROL_H
+#define JERK_TRACKING_CONTROL_H
+
+#include "geometric_controller/common.h"
+#include "geometric_controller/control.h"
+
+class JerkTrackingControl : public Control {
+ public:
+  JerkTrackingControl();
+  virtual ~JerkTrackingControl();
+  void Update(Eigen::Vector4d &curr_att, const Eigen::Vector4d &ref_att, const Eigen::Vector3d &ref_acc,
+              const Eigen::Vector3d &ref_jerk) override;
+
+ private:
+  Eigen::Vector3d last_ref_acc_{Eigen::Vector3d::Zero()};
+};
+
+#endif

--- a/geometric_controller/include/geometric_controller/nonlinear_attitude_control.h
+++ b/geometric_controller/include/geometric_controller/nonlinear_attitude_control.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018-2022 Jaeyoung Lim. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Controller base class
+ *
+ *
+ * @author Jaeyoung Lim <jalim@ethz.ch>
+ */
+
+#ifndef NONLINEAR_ATTITUDE_CONTROL_H
+#define NONLINEAR_ATTITUDE_CONTROL_H
+
+#include "geometric_controller/common.h"
+#include "geometric_controller/control.h"
+
+class NonlinearAttitudeControl : public Control {
+ public:
+  NonlinearAttitudeControl(double attctrl_tau);
+  virtual ~NonlinearAttitudeControl();
+  void Update(Eigen::Vector4d &curr_att, const Eigen::Vector4d &ref_att, const Eigen::Vector3d &ref_acc,
+              const Eigen::Vector3d &ref_jerk) override;
+
+ private:
+  double attctrl_tau_{1.0};
+};
+
+#endif

--- a/geometric_controller/include/geometric_controller/nonlinear_geometric_control.h
+++ b/geometric_controller/include/geometric_controller/nonlinear_geometric_control.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018-2022 Jaeyoung Lim. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Controller base class
+ *
+ *
+ * @author Jaeyoung Lim <jalim@ethz.ch>
+ */
+
+#ifndef NONLINEAR_GEOMETRIC_CONTROL_H
+#define NONLINEAR_GEOMETRIC_CONTROL_H
+
+#include "geometric_controller/common.h"
+#include "geometric_controller/control.h"
+
+class NonlinearGeometricControl : public Control {
+ public:
+  NonlinearGeometricControl(double attctrl_tau);
+  virtual ~NonlinearGeometricControl();
+  void Update(Eigen::Vector4d &curr_att, const Eigen::Vector4d &ref_att, const Eigen::Vector3d &ref_acc,
+              const Eigen::Vector3d &ref_jerk) override;
+
+ private:
+  double attctrl_tau_{1.0};
+};
+
+#endif

--- a/geometric_controller/src/geometric_controller.cpp
+++ b/geometric_controller/src/geometric_controller.cpp
@@ -268,10 +268,11 @@ void geometricCtrl::statusloopCallback(const ros::TimerEvent &event) {
   if (sim_enable_) {
     // Enable OFFBoard mode and arm automatically
     // This will only run if the vehicle is simulated
+    mavros_msgs::SetMode offb_set_mode;
     arm_cmd_.request.value = true;
-    offb_set_mode_.request.custom_mode = "OFFBOARD";
+    offb_set_mode.request.custom_mode = "OFFBOARD";
     if (current_state_.mode != "OFFBOARD" && (ros::Time::now() - last_request_ > ros::Duration(5.0))) {
-      if (set_mode_client_.call(offb_set_mode_) && offb_set_mode_.response.mode_sent) {
+      if (set_mode_client_.call(offb_set_mode) && offb_set_mode.response.mode_sent) {
         ROS_INFO("Offboard enabled");
       }
       last_request_ = ros::Time::now();

--- a/geometric_controller/src/jerk_tracking_control.cpp
+++ b/geometric_controller/src/jerk_tracking_control.cpp
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018-2022 Jaeyoung Lim. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Controller base class
+ *
+ *
+ * @author Jaeyoung Lim <jalim@ethz.ch>
+ */
+
+#include "geometric_controller/jerk_tracking_control.h"
+
+JerkTrackingControl::JerkTrackingControl() : Control() {}
+
+JerkTrackingControl::~JerkTrackingControl() {}
+
+void JerkTrackingControl::Update(Eigen::Vector4d &curr_att, const Eigen::Vector4d &ref_att,
+                                 const Eigen::Vector3d &ref_acc, const Eigen::Vector3d &ref_jerk) {
+  // Jerk feedforward control
+  // Based on: Lopez, Brett Thomas. Low-latency trajectory planning for high-speed navigation in unknown environments.
+  // Diss. Massachusetts Institute of Technology, 2016.
+  // Feedforward control from Lopez(2016)
+
+  double dt_ = 0.01;
+  // Numerical differentiation to calculate jerk_fb
+  const Eigen::Vector3d jerk_fb = (ref_acc - last_ref_acc_) / dt_;
+  const Eigen::Vector3d jerk_des = ref_jerk + jerk_fb;
+  const Eigen::Matrix3d R = quat2RotMatrix(curr_att);
+  const Eigen::Vector3d zb = R.col(2);
+
+  const Eigen::Vector3d jerk_vector =
+      jerk_des / ref_acc.norm() - ref_acc * ref_acc.dot(jerk_des) / std::pow(ref_acc.norm(), 3);
+  const Eigen::Vector4d jerk_vector4d(0.0, jerk_vector(0), jerk_vector(1), jerk_vector(2));
+
+  Eigen::Vector4d inverse(1.0, -1.0, -1.0, -1.0);
+  const Eigen::Vector4d q_inv = inverse.asDiagonal() * curr_att;
+  const Eigen::Vector4d qd = quatMultiplication(q_inv, ref_att);
+
+  const Eigen::Vector4d qd_star(qd(0), -qd(1), -qd(2), -qd(3));
+
+  const Eigen::Vector4d ratecmd_pre = quatMultiplication(quatMultiplication(qd_star, jerk_vector4d), qd);
+
+  Eigen::Vector4d ratecmd;
+  desired_rate_(0) = ratecmd_pre(2);  // TODO: Are the coordinate systems consistent?
+  desired_rate_(1) = (-1.0) * ratecmd_pre(1);
+  desired_rate_(2) = 0.0;
+  desired_thrust_(0) = 0.0;
+  desired_thrust_(1) = 0.0;
+  desired_thrust_(2) = ref_acc.dot(zb);  // Calculate thrust
+  last_ref_acc_ = ref_acc;
+  return;
+}

--- a/geometric_controller/src/nonlinear_attitude_control.cpp
+++ b/geometric_controller/src/nonlinear_attitude_control.cpp
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018-2022 Jaeyoung Lim. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Controller base class
+ *
+ *
+ * @author Jaeyoung Lim <jalim@ethz.ch>
+ */
+
+#include "geometric_controller/nonlinear_attitude_control.h"
+
+NonlinearAttitudeControl::NonlinearAttitudeControl(double attctrl_tau) : Control() { attctrl_tau_ = attctrl_tau; }
+
+NonlinearAttitudeControl::~NonlinearAttitudeControl() {}
+
+void NonlinearAttitudeControl::Update(Eigen::Vector4d &curr_att, const Eigen::Vector4d &ref_att,
+                                      const Eigen::Vector3d &ref_acc, const Eigen::Vector3d &ref_jerk) {
+  // Geometric attitude controller
+  // Attitude error is defined as in Brescianini, Dario, Markus Hehn, and Raffaello D'Andrea. Nonlinear quadrocopter
+  // attitude control: Technical report. ETH Zurich, 2013.
+
+  const Eigen::Vector4d inverse(1.0, -1.0, -1.0, -1.0);
+  const Eigen::Vector4d q_inv = inverse.asDiagonal() * curr_att;
+  const Eigen::Vector4d qe = quatMultiplication(q_inv, ref_att);
+  desired_rate_(0) = (2.0 / attctrl_tau_) * std::copysign(1.0, qe(0)) * qe(1);
+  desired_rate_(1) = (2.0 / attctrl_tau_) * std::copysign(1.0, qe(0)) * qe(2);
+  desired_rate_(2) = (2.0 / attctrl_tau_) * std::copysign(1.0, qe(0)) * qe(3);
+  const Eigen::Matrix3d rotmat = quat2RotMatrix(curr_att);
+  const Eigen::Vector3d zb = rotmat.col(2);
+  desired_thrust_(0) = 0.0;
+  desired_thrust_(1) = 0.0;
+  desired_thrust_(2) = ref_acc.dot(zb);
+}

--- a/geometric_controller/src/nonlinear_geometric_control.cpp
+++ b/geometric_controller/src/nonlinear_geometric_control.cpp
@@ -1,0 +1,68 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018-2022 Jaeyoung Lim. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Controller base class
+ *
+ *
+ * @author Jaeyoung Lim <jalim@ethz.ch>
+ */
+
+#include "geometric_controller/nonlinear_geometric_control.h"
+
+NonlinearGeometricControl::NonlinearGeometricControl(double attctrl_tau) : Control() { attctrl_tau_ = attctrl_tau; }
+
+NonlinearGeometricControl::~NonlinearGeometricControl() {}
+
+void NonlinearGeometricControl::Update(Eigen::Vector4d &curr_att, const Eigen::Vector4d &ref_att,
+                                       const Eigen::Vector3d &ref_acc, const Eigen::Vector3d &ref_jerk) {
+  // Geometric attitude controller
+  // Attitude error is defined as in Lee, Taeyoung, Melvin Leok, and N. Harris McClamroch. "Geometric tracking control
+  // of a quadrotor UAV on SE (3)." 49th IEEE conference on decision and control (CDC). IEEE, 2010.
+  // The original paper inputs moment commands, but for offboard control, angular rate commands are sent
+
+  Eigen::Vector4d ratecmd;
+  Eigen::Matrix3d rotmat;    // Rotation matrix of current attitude
+  Eigen::Matrix3d rotmat_d;  // Rotation matrix of desired attitude
+  Eigen::Vector3d error_att;
+
+  rotmat = quat2RotMatrix(curr_att);
+  rotmat_d = quat2RotMatrix(ref_att);
+
+  error_att = 0.5 * matrix_hat_inv(rotmat_d.transpose() * rotmat - rotmat.transpose() * rotmat_d);
+  desired_rate_ = (2.0 / attctrl_tau_) * error_att;
+  const Eigen::Vector3d zb = rotmat.col(2);
+  desired_thrust_(0) = 0.0;
+  desired_thrust_(1) = 0.0;
+  desired_thrust_(2) = ref_acc.dot(zb);
+}


### PR DESCRIPTION
**Problem Description**
Since we have three controllers, and have contributions that are adding more controllers, it would be better if we can structure the controllers properly.

This PR abstracts the different controllers into a parent class `Control` so that they have a homogeneous interface. This would allow the following benefits
- Clear test points for unit testing different controllers
- Benchmarking controller performances without running the SITL simulation
- Easier to add a new controller without modifying the execution logic of the node

